### PR TITLE
fixed x509 error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#19331E",
+        "titleBar.activeBackground": "#23482A",
+        "titleBar.activeForeground": "#F7FBF8"
+    }
+}

--- a/article.go
+++ b/article.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"html/template"
 	"io"
 	"net/http"
@@ -40,6 +41,9 @@ type Article struct {
 }
 
 func (a Article) Download() (io.Reader, error) {
+	// Bypass x509 error for downloading articles
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 	r, w := io.Pipe()
 
 	resp, err := http.Get(a.URL())


### PR DESCRIPTION
Fixed an error where the client would refuse to download a webpage if it had an unsecure certificate. This code allows the client to bypass the 509 error. 